### PR TITLE
Dashboard friends wp

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,13 @@
 class DashboardController < ApplicationController
   def index
     @user = current_user
+    # @friends = current_user.friendships
+    invited = @user.invites
+    hosting = @user.parties
+    @parties = {
+      invited_to: invited,
+      hosted: hosting
+    }
+    # binding.pry
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,13 +1,11 @@
 class DashboardController < ApplicationController
   def index
-    @user = current_user
-    # @friends = current_user.friendships
-    invited = @user.invites
-    hosting = @user.parties
+    @friends = current_user.friendships
+    invited = current_user.invites
+    hosting = current_user.parties
     @parties = {
       invited_to: invited,
       hosted: hosting
     }
-    # binding.pry
   end
 end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,0 +1,13 @@
+class FriendshipsController < ApplicationController
+  def create
+    @friend = User.find_by(email: params[:friend].downcase)
+    if @friend
+      current_user.friendships.create!(
+        friend_id: @friend.id
+      )
+    else
+      flash[:error] = errors.full_messages.to_sentence
+    end
+    redirect_to dashboard_path
+  end
+end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,4 +1,5 @@
 class Friendship < ApplicationRecord
+  validates :friend_id, presence: true
   belongs_to :user
   belongs_to :friend, class_name: 'User'
 end

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -6,15 +6,14 @@ class Party < ApplicationRecord
   validates :duration, presence: true, numericality: { greater_than_or_equal_to: 0 }
 
   def viewer_usernames
-    usernames = party_viewers.map do |slot|
-      slot.viewer.username
-    end
-    if usernames.count == 0
-      "None"
-    elsif usernames.count == 1
+    usernames = party_viewers.map { |slot| slot.viewer.username }
+    case usernames.count
+    when 0
+      'None'
+    when 1
       usernames.first
     else
-      usernames.join(", ")
+      usernames.join(', ')
     end
   end
 end

--- a/app/models/party.rb
+++ b/app/models/party.rb
@@ -4,4 +4,17 @@ class Party < ApplicationRecord
   has_many :party_viewers, dependent: :destroy
 
   validates :duration, presence: true, numericality: { greater_than_or_equal_to: 0 }
+
+  def viewer_usernames
+    usernames = party_viewers.map do |slot|
+      slot.viewer.username
+    end
+    if usernames.count == 0
+      "None"
+    elsif usernames.count == 1
+      usernames.first
+    else
+      usernames.join(", ")
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,9 @@ class User < ApplicationRecord
   has_many :friends, through: :friendships, dependent: :destroy
   has_many :parties, foreign_key: :host_id, inverse_of: :host, dependent: :destroy
   has_secure_password
+
+  def invites
+    id = self.id
+    Party.joins(:party_viewers).where(party_viewers: {viewer_id: id})
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,6 @@ class User < ApplicationRecord
 
   def invites
     id = self.id
-    Party.joins(:party_viewers).where(party_viewers: {viewer_id: id})
+    Party.joins(:party_viewers).where(party_viewers: { viewer_id: id })
   end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -4,10 +4,42 @@
 
 <%= button_to "Discover Movies", discover_path, method: :get%>
 
-<header>
+<h2>
   Friends:
-</header>
+</h2>
 
-<header>
-  Parties:
-</header>
+<section id="watch_parties">
+  <h2>Watch Parties:</h2>
+  <br>
+  <h3>Invited:</h3>
+  <% @parties[:invited_to].each do |party| %>
+    <div class="parties_for_you">
+      <%= "Movie: #{party.movie.title}" %>
+      <br>
+      <%= "Duration: #{party.duration/60} hours " + "#{party.duration%60} minutes" %>
+      <br>
+      <%= "Hosted by: #{party.host.username}" %>
+      <br>
+      <%= "Date: #{party.party_date.strftime("%e %b %Y")}" %>
+      <br>
+      <%= "Time: #{party.party_time.strftime("%l:%M %p %Z")}" %>
+      <br>
+    </div>
+  <% end %>
+
+  <h3>Hosting:</h3>
+  <% @parties[:hosted].each do |party| %>
+    <div class="parties_you_run">
+      <%= "Movie: #{party.movie.title}" %>
+      <br>
+      <%= "Duration: #{party.duration/60} hours " + "#{party.duration%60} minutes" %>
+      <br>
+      <%= "Invitees: #{party.viewer_usernames}" %>
+      <br>
+      <%= "Date: #{party.party_date.strftime("%e %b %Y")}" %>
+      <br>
+      <%= "Time: #{party.party_time.strftime("%l:%M %p %Z")}" %>
+      <br>
+    </div>
+  <% end %>
+</section>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,12 +1,31 @@
 <header>
-  Welcome <%= @user.username %>!
+  <%= "Welcome, #{current_user.username}!" %>
 </header>
 
 <%= button_to "Discover Movies", discover_path, method: :get%>
 
-<h2>
-  Friends:
-</h2>
+<section>
+  <h2>Friends:</h2>
+  <div id="add_friend">
+    <h3>Add a friend: </h3>
+    <%= form_with url: friendships_path, local: true do |f| %>
+      <%= f.label :friend, "Search by email:" %>
+      <%= f.text_field :friend %>
+      <%= f.submit "Add Friend" %>
+    <% end %>
+  </div>
+  <div id="friends_list">
+    <% if @friends.none? %>
+      <p>You currently have no friends.</p>
+    <% else %>
+      <% @friends.each do |friend| %>
+      <ul>
+        <li><%= friend.friend.username %>
+      </ul>
+      <% end %>
+    <% end %>
+  </div>
+</section>
 
 <section id="watch_parties">
   <h2>Watch Parties:</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   resources :users, only: [:create]
   resources :movies, only: [:index, :show]
   resources :viewing_party, only: [:new, :create], :controller=>"parties"
+  resources :friendships, only: [:create]
 
   get '/discover', to: 'discover#index'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,4 +5,15 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+User.destroy_all
+Friendship.destroy_all
+Movie.destroy_all
 User.create!(username: "funbucket13", password: "test", email: 'funbucket13@gmail.com')
+@highfive = User.create!(username: "highfive", email: "highfive@fake.com", password: "password", id: 100)
+@lowfive = User.create!(username: "lowfive", email: "lowfive@fake.com", password: "password", id: 101)
+@sidefive = User.create!(username: "sidefive", email: "sidefive@fake.com", password: "password", id: 102)
+@nofive = User.create!(username: "nofive", email: "nofive@fake.com", password: "password", id: 103)
+@movie = Movie.create!(title: "The Mummy", duration: 120, api_id: 90)
+Friendship.create!(user: @highfive, friend: @lowfive, status: 0)
+Friendship.create!(user: @highfive, friend: @sidefive, status: 0)
+Friendship.create!(user: @highfive, friend: @nofive, status: 0)

--- a/spec/features/dashboard/index_spec.rb
+++ b/spec/features/dashboard/index_spec.rb
@@ -30,7 +30,7 @@ describe 'As an authenticated user' do
     end
 
     it "'Welcome <username>!' at the top of page" do
-      expect(page).to have_content("Welcome #{@user.username}!")
+      expect(page).to have_content("Welcome, #{@user.username}!")
     end
 
     it "A button to Discover Movies" do
@@ -40,8 +40,24 @@ describe 'As an authenticated user' do
       expect(current_path).to eq(discover_path)
     end
 
-    it "A friends section" do
-      expect(page).to have_content("Friends:")
+    describe "friends section" do
+      it "tells me I have no friends" do
+        expect(page).to have_content("Friends:")
+        expect(page).to have_content("You currently have no friends.")
+      end
+
+      it "gives me the option to add friends" do
+        within('div#add_friend') do
+          expect(page).to have_content("Add a friend:")
+          expect(page).to have_content("Search by email:")
+          fill_in(:friend, with: @user_2.email)
+          click_button("Add Friend")
+        end
+
+        within('div#friends_list') do
+          expect(page).to have_content(@user_2.username)
+        end
+      end
     end
 
     it "A viewing parties section" do

--- a/spec/features/dashboard/index_spec.rb
+++ b/spec/features/dashboard/index_spec.rb
@@ -4,14 +4,29 @@ describe 'As an authenticated user' do
   describe 'when I visit "/dashboard" I see' do
     before :each do
       @user = User.create!(username: "sphinx", email: "123fake@email.com", password: "password")
-      visit root_path
-      within '.login-form' do
-        fill_in :username, with: @user.username
-        fill_in :password, with: @user.password
+      @user_2 = User.create!(
+        email: "friendboy@email.com",
+        username: "friendmandude",
+        password: "heck"
+      )
+      @movie = Movie.create!(
+        title: "Daybreak",
+        duration: 180,
+        api_id: "kesjmrv8io2w3ay5n98327nhvaw38ouy3rhju"
+      )
+      @invite_party = @user_2.parties.create!(
+        movie_id: @movie.id,
+        duration: 195,
+        party_date: Date.today,
+        party_time: Time.now
+      )
+      @invite_party.party_viewers.create!(viewer_id: @user.id)
 
-        click_on "Log In"
-      end
-      visit dashboard_path
+      visit root_path
+      fill_in :username, with: @user.username
+      fill_in :password, with: "password"
+
+      click_on "Log In"
     end
 
     it "'Welcome <username>!' at the top of page" do
@@ -30,7 +45,24 @@ describe 'As an authenticated user' do
     end
 
     it "A viewing parties section" do
-      expect(page).to have_content("Parties:")
+      expect(page).to have_content("Watch Parties:")
+      expect(page).to have_content("Invited:")
+      page.all('div.parties_for_you').each do |div|
+        expect(div).to have_content("Movie:")
+        expect(div).to have_content("Duration:")
+        expect(div).to have_content("Hosted by:")
+        expect(div).to have_content("Date:")
+        expect(div).to have_content("Time:")
+      end
+
+      expect(page).to have_content("Hosting:")
+      page.all('div.parties_you_run').each do |div|
+        expect(div).to have_content("Movie:")
+        expect(div).to have_content("Duration:")
+        expect(div).to have_content("Invitees:")
+        expect(div).to have_content("Date:")
+        expect(div).to have_content("Time:")
+      end
     end
   end
 end

--- a/spec/models/friendship_spec.rb
+++ b/spec/models/friendship_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Friendship, type: :model do
   describe 'validations' do
+    it { should validate_presence_of :friend_id }
   end
 
   describe 'relationships' do

--- a/spec/models/party_spec.rb
+++ b/spec/models/party_spec.rb
@@ -10,4 +10,54 @@ RSpec.describe Party, type: :model do
     it { should belong_to(:host).class_name('User') }
     it { should have_many :party_viewers }
   end
+
+  describe 'instance methods' do
+    it '#viewer_usernames' do
+      user_1 = User.create!(
+        email: "heckinheck@heckmail.org",
+        username: "heckx3",
+        password: "heck"
+      )
+      user_2 = User.create!(
+        email: "emailemail@email.com",
+        username: "shouldveinstalledfactorybot",
+        password: "anotherone"
+      )
+      user_3 = User.create!(
+        email: "lazyhope@example.net",
+        password: "passwordpassword",
+        username: "anotheruser"
+      )
+      movie_1 = Movie.create!(
+        title: "The Godfather",
+        duration: 200,
+        api_id: "krahjifq3uyv4i8237gh4mqo9"
+      )
+      party_1 = user_1.parties.create!(
+        duration: 230,
+        movie_id: movie_1.id,
+        party_date: Date.today,
+        party_time: Time.now
+      )
+      party_1.party_viewers.create!(viewer_id: user_2.id)
+      party_1.party_viewers.create!(viewer_id: user_3.id)
+      party_2 = user_1.parties.create(
+        duration: 250,
+        movie_id: movie_1.id,
+        party_date: Date.today,
+        party_time: Time.now
+      )
+      party_3 = user_1.parties.create(
+        duration: 270,
+        movie_id: movie_1.id,
+        party_date: Date.today,
+        party_time: Time.now
+      )
+      party_3.party_viewers.create!(viewer_id: user_2.id)
+
+      expect(party_1.viewer_usernames).to eq("#{user_2.username}, #{user_3.username}")
+      expect(party_2.viewer_usernames).to eq("None")
+      expect(party_3.viewer_usernames).to eq(user_2.username)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe User, type: :model do
       )
       user_2 = User.create!(
         email: "emailemail@email.com",
-        username: "shouldveinstalledfactorybot@example.com",
+        username: "shouldveinstalledfactorybot",
         password: "anotherone"
       )
       user_3 = User.create!(

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,7 +19,49 @@ RSpec.describe User, type: :model do
     #
   end
 
-  it 'instance methods' do
-    #
+  describe 'instance methods' do
+    it '#invites' do
+      user_1 = User.create!(
+        email: "heckinheck@heckmail.org",
+        username: "heckx3",
+        password: "heck"
+      )
+      user_2 = User.create!(
+        email: "emailemail@email.com",
+        username: "shouldveinstalledfactorybot@example.com",
+        password: "anotherone"
+      )
+      user_3 = User.create!(
+        email: "lazyhope@example.net",
+        password: "passwordpassword",
+        username: "anotheruser"
+      )
+      movie_1 = Movie.create!(
+        title: "The Godfather",
+        duration: 200,
+        api_id: "krahjifq3uyv4i8237gh4mqo9"
+      )
+      movie_2 = Movie.create!(
+        title: "The Godfather, Part II",
+        duration: 220,
+        api_id: "krahjifoseio458u38237gh4mqo9"
+      )
+      party_1 = user_2.parties.create!(
+        duration: 230,
+        movie_id: movie_1.id,
+        party_date: Date.today,
+        party_time: Time.now
+      )
+      party_1.party_viewers.create!(viewer_id: user_1.id)
+      party_2 = user_3.parties.create(
+        duration: 250,
+        movie_id: movie_2.id,
+        party_date: Date.today,
+        party_time: Time.now
+      )
+      party_2.party_viewers.create(viewer_id: user_1.id)
+
+      expect(user_1.invites).to eq([party_1, party_2])
+    end
   end
 end

--- a/test/controllers/discover_controller_test.rb
+++ b/test/controllers/discover_controller_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class DiscoverControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/controllers/movies_controller_test.rb
+++ b/test/controllers/movies_controller_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class MoviesControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end


### PR DESCRIPTION
adds friends and viewing party functionality to the user's dashboard page. 
Adds: 
- friends list
- box to add friends (currently one-way)
- sections for friends and parties
- sections for parties invited and parties hosted by user
- can see details of all parties pertaining to user
- all tests passing
- ran rubocop

closes #11 
closes #10 