### PR TITLE
Fix viewing party path with no params

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -12,26 +12,8 @@ class MoviesController < ApplicationController
   end
 
   def show
-    @user = current_user
     data = MovieService.movie_by_id(params[:id])
     @movie = MovieApi.new(data)
-    @dbmovie = Movie.new
-  end
-
-  def create
-    movie = Movie.create(movie_params)
-    if movie.save
-      flash[:success] = "Please fill out the folowing form to create a party for #{movie.title}"
-      redirect_to new_movie_viewing_party_path(movie)
-    else
-      flash[:error] = movie.errors.full_messages.to_sentence
-      render [movie]
-    end
-  end
-
-  private
-
-  def movie_params
-    params.permit(:title, :duration, :api_id, :poster_path)
+    session[:movie] = {api_id: @movie.id, title: @movie.title, duration: @movie.duration, poster_path: @movie.poster_path}
   end
 end

--- a/app/controllers/parties_controller.rb
+++ b/app/controllers/parties_controller.rb
@@ -1,10 +1,11 @@
 class PartiesController < ApplicationController
-  before_action :movie, only: %i[new create]
   def new
     @viewing_party = Party.new
+    @movie = session[:movie]
   end
 
   def create
+    @movie = Movie.find_or_create_by(session[:movie])
     party = @movie.parties.create(party_params)
     if party.save
       @pv = PartyViewer.create_multiple_viewers(params[:friends], party.id)
@@ -30,9 +31,5 @@ class PartiesController < ApplicationController
 
   def party_params
     params.permit(:duration, :party_date, :party_time, :host_id)
-  end
-
-  def movie
-    @movie = Movie.find(params[:movie_id])
   end
 end

--- a/app/views/movies/show.html.erb
+++ b/app/views/movies/show.html.erb
@@ -34,7 +34,7 @@
 </section>
 
 <div class="viewing-party">
-  <%= button_to 'Create Viewing Party for Movie', movies_path, method: :post, params: {title: @movie.title, duration: @movie.duration, poster_path: @movie.poster_path, api_id: @movie.id}, local: true %>
+  <%= button_to 'Create Viewing Party for Movie', new_viewing_party_path, method: :get, local: true %>
 </div>
 
 <h3 class="white_glow"><center>Cast:<center></h3>

--- a/app/views/parties/new.html.erb
+++ b/app/views/parties/new.html.erb
@@ -1,12 +1,12 @@
 <header><center>Welcome <%= current_user.username %>!</center></header>
-<h2><center> <%= @movie.title %> </center></h2>
+<h2><center> <%= @movie["title"] %> </center></h2>
 <center>
-  <img src="https://image.tmdb.org/t/p/w200<%= @movie.poster_path %>">
+  <img src="https://image.tmdb.org/t/p/w200<%= @movie["poster_path"] %>">
   <div class = "login-form">
-    <%= form_with url: movie_viewing_party_index_path, method: :post, local: true do |form| %>
+    <%= form_with url: viewing_party_index_path, method: :post, local: true do |form| %>
       <%= form.hidden_field :host_id, value: current_user.id %>
       <%= form.label :duration, "Duration of Party:" %>
-      <%= form.number_field :duration, required: true, class: "form-control", min: @movie.duration, value: @movie.duration %>
+      <%= form.number_field :duration, required: true, class: "form-control", min: @movie["duration"], value: @movie["duration"] %>
       <%= form.label :party_date, "Day:" %>
       <%= form.date_field :party_date, required: true, class: "form-control" %>
       <%= form.label :party_time, "Start Time:" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,9 +9,8 @@ Rails.application.routes.draw do
 
   resources :friendships, only: [:create]
 
-  resources :movies, only: [:index, :show, :create] do
-    resources :viewing_party, only: [:new, :create], :controller=>"parties"
-  end
+  resources :movies, only: [:index, :show]
+  resources :viewing_party, only: [:new, :create], :controller=>"parties"
 
   get '/discover', to: 'discover#index'
 end

--- a/spec/features/movies/show_spec.rb
+++ b/spec/features/movies/show_spec.rb
@@ -27,7 +27,7 @@ describe 'As an authenticated user' do
         expect(page).to have_button('Create Viewing Party for Movie')
         click_button
       end
-      #expect(current_path).to eq(new_movie_viewing_party_path(@movie.id))
+      expect(current_path).to eq(new_viewing_party_path)
     end
     describe "And I should see the following information about the movie:" do
       it "Movie title", :vcr do


### PR DESCRIPTION
Added session for movie so that params would not have to appear in the URL
Close #35 